### PR TITLE
allow to send backbutton event to close fullscreen banner on Android

### DIFF
--- a/src/android/ChartboostPlugin.java
+++ b/src/android/ChartboostPlugin.java
@@ -182,6 +182,11 @@ public class ChartboostPlugin extends CordovaPlugin {
 						
 			return true;
 		}
+		else if (action.equals("sendBackButtonPressed")) {
+			sendBackButtonPressed(action, args, callbackContext);
+						
+			return true;
+		}
 		
 		return false; // Returning false results in a "MethodNotFound" error.
 	}
@@ -312,6 +317,16 @@ public class ChartboostPlugin extends CordovaPlugin {
 			}
 		});
 	}
+
+	private void sendBackButtonPressed(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+		
+		cordova.getActivity().runOnUiThread(new Runnable(){
+			@Override
+			public void run() {
+				_sendBackButtonPressed();
+			}
+		});
+	}
 	
 	public void _setLicenseKey(String email, String licenseKey) {
 		this.email = email;
@@ -398,6 +413,16 @@ public class ChartboostPlugin extends CordovaPlugin {
 		rewardedVideoAdPreload = false;
 		
 		Chartboost.showRewardedVideo(location);	
+	}
+
+	private void _sendBackButtonPressed() {
+
+		if (Chartboost.onBackPressed()) {
+			Log.d(LOG_TAG, "Sent BackButton, result: true");
+		}
+		else {
+			Log.d(LOG_TAG, "Sent BackButton, result: false");
+		}
 	}
 	
 	class MyChartboostDelegate extends ChartboostDelegate {

--- a/www/chartboost.js
+++ b/www/chartboost.js
@@ -305,6 +305,15 @@ module.exports = {
             [location]
         ); 
     },
+    sendBackButtonPressed: function() {
+		cordova.exec(
+			null,
+            null,
+            'ChartboostPlugin',
+            'sendBackButtonPressed',
+            []
+        ); 
+    },
 //cranberrygame start; deprecated	
 	loadedFullScreenAd: function() {
 		return this._loadedInterstitialAd;


### PR DESCRIPTION
I also added this on your construct 2 plugin:

edittime.js
AddAction(6, af_none, "Send BackButton pressed", "Send BackButton pressed", "Send BackButton pressed", "Send BackButton pressed", "SendBackButtonPressed");

runtime.js
Acts.prototype.SendBackButtonPressed = function ()
    {
        if (!(this.runtime.isAndroid || this.runtime.isiOS))
            return;
                 if (typeof window["chartboost"] == 'undefined')
                        return;  
        if (appId == "" || appSignature == "")
            return;  
        window["chartboost"]["sendBackButtonPressed"]();  
    };
